### PR TITLE
feat: add opencode flake input for latest versions

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -92,12 +92,33 @@
         "type": "github"
       }
     },
+    "opencode": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs-unstable"
+        ]
+      },
+      "locked": {
+        "lastModified": 1769817482,
+        "narHash": "sha256-Rb5o+NBUu8XOtkd+qyKoA167WzoJ7M0hm+aubWOpcGY=",
+        "owner": "sst",
+        "repo": "opencode",
+        "rev": "aef0e58ad7c8fc299ac7bdf0bb63a54d6ab878e3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sst",
+        "repo": "opencode",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "gh-aipr": "gh-aipr",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs",
-        "nixpkgs-unstable": "nixpkgs-unstable"
+        "nixpkgs-unstable": "nixpkgs-unstable",
+        "opencode": "opencode"
       }
     },
     "systems": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,6 +8,9 @@
     nixpkgs-unstable.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     gh-aipr.url = "github:wannabehero/gh-aipr";
     gh-aipr.inputs.nixpkgs.follows = "nixpkgs";
+    # Always use latest opencode from upstream
+    opencode.url = "github:sst/opencode";
+    opencode.inputs.nixpkgs.follows = "nixpkgs-unstable";
   };
 
   outputs =
@@ -17,6 +20,7 @@
       nixpkgs,
       nixpkgs-unstable,
       gh-aipr,
+      opencode,
     }:
     let
       systems = [
@@ -40,7 +44,7 @@
           # use as pkgs.unstable.<pkg> in modules
           unstable = import nixpkgs-unstable {
             inherit (prev) system config;
-            overlays = [ ];
+            overlays = import ./pkgs/overlays.nix { inherit opencode; };
           };
           shell-utils = final.callPackage ./pkgs/shell-utils.nix { };
         })

--- a/home/home.nix
+++ b/home/home.nix
@@ -14,7 +14,7 @@ in
     modules/go.nix
     modules/javascript.nix
     modules/kubernetes.nix
-    modules/opencode
+    modules/ai
     modules/ssh.nix
     modules/terraform.nix
   ];

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -1,4 +1,9 @@
-{ config, lib, pkgs, ... }:
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
 let
   inherit (lib) concatStringsSep mapAttrs;
 
@@ -6,11 +11,19 @@ let
   mcpServers = {
     nixos = {
       command = "docker";
-      args = [ "run" "--rm" "-i" "ghcr.io/utensils/mcp-nixos" ];
+      args = [
+        "run"
+        "--rm"
+        "-i"
+        "ghcr.io/utensils/mcp-nixos"
+      ];
     };
     gcloud = {
       command = "npx";
-      args = [ "-y" "@google-cloud/gcloud-mcp" ];
+      args = [
+        "-y"
+        "@google-cloud/gcloud-mcp"
+      ];
     };
   };
 

--- a/home/work.nix
+++ b/home/work.nix
@@ -20,7 +20,7 @@ in
     ./darwin.nix
     modules/go.nix
     modules/kubernetes.nix
-    modules/opencode
+    modules/ai
     modules/terraform.nix
   ];
 

--- a/pkgs/overlays.nix
+++ b/pkgs/overlays.nix
@@ -1,0 +1,9 @@
+# Overlays for pkgs.unstable
+{ opencode }:
+[
+  # Always use latest opencode from upstream flake
+  (final: prev: {
+    opencode = opencode.packages.${prev.system}.default;
+  })
+  # gemini-cli from nixpkgs-unstable (updates naturally with flake.lock)
+]


### PR DESCRIPTION
Add opencode as a flake input from github:sst/opencode to always get the latest version directly from upstream. This replaces the nixpkgs version which can lag behind significantly.

- opencode: now at v1.1.47 (latest) via upstream flake
- gemini-cli: stays on nixpkgs-unstable (v0.23.0), updates with flake.lock

To update opencode: nix flake update opencode
To update gemini-cli: nix flake update nixpkgs-unstable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily Nix flake wiring/packaging changes; the main risk is build/eval issues from the new upstream input and overlay override.
> 
> **Overview**
> **`opencode` is now sourced directly from the upstream flake.** This adds a new `opencode` flake input (following `nixpkgs-unstable`) and an `unstable` overlay (`pkgs/overlays.nix`) that overrides `pkgs.unstable.opencode` to use `opencode.packages.<system>.default`.
> 
> Home-manager configs (`home.nix` and `work.nix`) switch from importing `modules/opencode` to `modules/ai` (which still installs `opencode`/`gemini-cli`), and `flake.lock` is updated to pin the upstream `opencode` revision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45bff4acbf6cb78ca77dba917326870a5ca27237. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->