### PR TITLE
feat: add gemini-cli-bin overlay with Renovate automation

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,48 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended",
+    "helpers:pinGitHubActionDigests"
   ],
-  "automerge": true
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
+  "nix": {
+    "enabled": true
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["^pkgs/overlays\\.nix$"],
+      "matchStrings": [
+        "#\\s*renovate:\\s*datasource=(?<datasource>[^\\s]+)\\s+depName=(?<depName>[^\\s]+)\\s*\\n\\s*version\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "extractVersionTemplate": "^v?(?<version>.*)$"
+    }
+  ],
+  "packageRules": [
+    {
+      "description": "Automerge minor and patch updates for GitHub Actions",
+      "matchManagers": ["github-actions"],
+      "matchUpdateTypes": ["minor", "patch", "digest"],
+      "automerge": true
+    },
+    {
+      "description": "Automerge flake.lock updates",
+      "matchManagers": ["nix"],
+      "automerge": true
+    },
+    {
+      "description": "Update gemini-cli-bin with hash refresh",
+      "matchPackageNames": ["google-gemini/gemini-cli"],
+      "versioning": "semver",
+      "extractVersion": "^v(?<version>.*)$",
+      "automerge": true,
+      "postUpgradeTasks": {
+        "commands": [".github/scripts/update-gemini-hash.sh"],
+        "fileFilters": ["pkgs/overlays.nix"],
+        "executionMode": "branch"
+      }
+    }
+  ]
 }

--- a/.github/scripts/update-gemini-hash.sh
+++ b/.github/scripts/update-gemini-hash.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Post-upgrade script for Renovate to update gemini-cli-bin hash
+set -euo pipefail
+
+OVERLAYS_FILE="pkgs/overlays.nix"
+
+# Extract the current version from overlays.nix
+VERSION=$(grep -oP 'version = "\K[^"]+' "$OVERLAYS_FILE" | head -1)
+
+if [[ -z "$VERSION" ]]; then
+  echo "Error: Could not extract version from $OVERLAYS_FILE"
+  exit 1
+fi
+
+echo "Updating hash for gemini-cli-bin v${VERSION}..."
+
+# Fetch the new hash
+URL="https://github.com/google-gemini/gemini-cli/releases/download/v${VERSION}/gemini.js"
+NEW_HASH=$(nix-prefetch-url "$URL" 2>/dev/null | xargs nix hash convert --hash-algo sha256 --to sri)
+
+if [[ -z "$NEW_HASH" ]]; then
+  echo "Error: Could not fetch hash for $URL"
+  exit 1
+fi
+
+echo "New hash: $NEW_HASH"
+
+# Update the hash in overlays.nix
+sed -i "s|hash = \"sha256-[^\"]*\"|hash = \"$NEW_HASH\"|" "$OVERLAYS_FILE"
+
+echo "Updated $OVERLAYS_FILE with new hash"

--- a/.github/workflows/flake-update.yaml
+++ b/.github/workflows/flake-update.yaml
@@ -1,0 +1,58 @@
+name: flake-update
+on:
+  schedule:
+    # Run daily at 6am UTC
+    - cron: "0 6 * * *"
+  workflow_dispatch: # Allow manual trigger
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: DeterminateSystems/nix-installer-action@v17
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Update flake.lock
+        run: nix flake update
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet flake.lock; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create Pull Request
+        id: cpr
+        if: steps.changes.outputs.changed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: "chore(nix): update flake.lock"
+          title: "chore(nix): update flake.lock"
+          body: |
+            Automated flake.lock update.
+
+            ```
+            nix flake update
+            ```
+
+            This PR was created automatically by the flake-update workflow.
+          branch: flake-update
+          delete-branch: true
+          labels: dependencies
+
+      - name: Enable auto-merge
+        if: steps.cpr.outputs.pull-request-number
+        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/flake-update.yaml
+++ b/.github/workflows/flake-update.yaml
@@ -32,27 +32,42 @@ jobs:
           fi
 
       - name: Create Pull Request
-        id: cpr
         if: steps.changes.outputs.changed == 'true'
-        uses: peter-evans/create-pull-request@v7
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore(nix): update flake.lock"
-          title: "chore(nix): update flake.lock"
-          body: |
-            Automated flake.lock update.
-
-            ```
-            nix flake update
-            ```
-
-            This PR was created automatically by the flake-update workflow.
-          branch: flake-update
-          delete-branch: true
-          labels: dependencies
-
-      - name: Enable auto-merge
-        if: steps.cpr.outputs.pull-request-number
-        run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          BRANCH="flake-update"
+          
+          # Configure git
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          
+          # Create or update branch
+          git checkout -B "$BRANCH"
+          git add flake.lock
+          git commit -m "chore(nix): update flake.lock"
+          git push -f origin "$BRANCH"
+          
+          # Check if PR already exists
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --json number --jq '.[0].number // empty')
+          
+          if [ -n "$EXISTING_PR" ]; then
+            echo "PR #$EXISTING_PR already exists, updated branch"
+          else
+            # Create PR and enable auto-merge
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "chore(nix): update flake.lock" \
+              --body "$(cat <<'EOF'
+          Automated flake.lock update.
+
+          ```
+          nix flake update
+          ```
+
+          This PR was created automatically by the flake-update workflow.
+          EOF
+          )"
+            gh pr merge --auto --squash "$BRANCH"
+          fi

--- a/.github/workflows/nix.yaml
+++ b/.github/workflows/nix.yaml
@@ -5,6 +5,11 @@ on:
       - .github/workflows/nix.yaml
       - flake.lock
       - "**/*.nix"
+  pull_request:
+    paths:
+      - .github/workflows/nix.yaml
+      - flake.lock
+      - "**/*.nix"
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -12,18 +17,19 @@ jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v17
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - uses: DeterminateSystems/flake-checker-action@main
+      - uses: DeterminateSystems/flake-checker-action@v9
       - run: nix flake check
+
   linux:
     runs-on: ubuntu-latest
     needs: check
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v17
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: cachix/cachix-action@v16
@@ -37,8 +43,8 @@ jobs:
     runs-on: macos-latest
     needs: check
     steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
-      - uses: DeterminateSystems/nix-installer-action@main
+      - uses: actions/checkout@v4
+      - uses: DeterminateSystems/nix-installer-action@v17
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
       - uses: cachix/cachix-action@v16

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -386,7 +386,7 @@ in
 {
   home.packages = with pkgs.unstable; [
     opencode
-    gemini-cli
+    gemini-cli-bin
   ];
 
   # opencode config, skills, and commands (primary tool)

--- a/pkgs/overlays.nix
+++ b/pkgs/overlays.nix
@@ -5,5 +5,16 @@
   (final: prev: {
     opencode = opencode.packages.${prev.system}.default;
   })
-  # gemini-cli from nixpkgs-unstable (updates naturally with flake.lock)
+
+  # gemini-cli-bin: override to latest release from GitHub
+  (final: prev: {
+    gemini-cli-bin = prev.gemini-cli-bin.overrideAttrs (oldAttrs: rec {
+      # renovate: datasource=github-releases depName=google-gemini/gemini-cli
+      version = "0.25.2";
+      src = prev.fetchurl {
+        url = "https://github.com/google-gemini/gemini-cli/releases/download/v${version}/gemini.js";
+        hash = "sha256-k5zGtNlpW+T41DxrKexaqLinV5CzrQYepW+MKVYoS9o=";
+      };
+    });
+  })
 ]


### PR DESCRIPTION
## Summary
Add gemini-cli-bin overlay pinned to GitHub releases with full Renovate automation for dependency updates.

## Changes
- Switch from `gemini-cli` to `gemini-cli-bin` (pre-built binary, easier to overlay)
- Add overlay in `pkgs/overlays.nix` to pin gemini-cli-bin to v0.25.2
- Add Renovate custom regex manager to detect version updates from GitHub releases
- Add `.github/scripts/update-gemini-hash.sh` post-upgrade script to refresh Nix hash
- Enable Renovate nix manager for `flake.lock` updates with automerge
- Fix `nix.yaml` workflow:
  - Pin `actions/checkout` to v4 (was suspicious SHA)
  - Pin `DeterminateSystems/*` actions to versioned tags (was `@main`)
  - Add `pull_request` trigger for PR validation
- Add `.github/workflows/flake-update.yaml` daily workflow as backup flake updater
- Configure `platformAutomerge` for GitHub native auto-merge after CI passes

## Test Plan
- [ ] `nix flake check` passes
- [ ] `nix build .#legacyPackages.x86_64-linux.unstable.gemini-cli-bin` succeeds
- [ ] CI workflow runs on this PR
- [ ] Renovate detects gemini-cli-bin for updates (check Renovate dashboard after merge)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces automation that can auto-merge dependency and `flake.lock` updates and adds a workflow that pushes branches/creates PRs, so misconfiguration could cause unintended updates despite being scoped to Nix/CI tooling.
> 
> **Overview**
> Switches the AI home-manager module from `gemini-cli` to `gemini-cli-bin`, and adds a `pkgs/overlays.nix` override that pins `gemini-cli-bin` to a specific GitHub release (version + fetch URL + sha256).
> 
> Expands `.github/renovate.json` to enable Nix updates, add a regex manager to track the overlay version, and run a post-upgrade script (`update-gemini-hash.sh`) to recompute the Nix hash; also enables auto-merge for flake/GitHub Actions updates.
> 
> Updates CI by adding PR triggers and pinning GitHub Actions to tagged versions in `nix.yaml`, and introduces a scheduled `flake-update` workflow that opens/auto-merges `flake.lock` update PRs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f650d324631dcabe317efc77d99d24868b7d7c66. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->