### PR TITLE
fix: use GitHub Action for Nix hash updates instead of Renovate postUpgradeTasks

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -33,16 +33,11 @@
       "automerge": true
     },
     {
-      "description": "Update gemini-cli-bin with hash refresh",
+      "description": "Update gemini-cli-bin version",
       "matchPackageNames": ["google-gemini/gemini-cli"],
       "versioning": "semver",
       "extractVersion": "^v(?<version>.*)$",
-      "automerge": true,
-      "postUpgradeTasks": {
-        "commands": [".github/scripts/update-gemini-hash.sh"],
-        "fileFilters": ["pkgs/overlays.nix"],
-        "executionMode": "branch"
-      }
+      "automerge": true
     }
   ]
 }

--- a/.github/workflows/update-nix-hash.yaml
+++ b/.github/workflows/update-nix-hash.yaml
@@ -1,0 +1,45 @@
+name: update-nix-hash
+on:
+  pull_request:
+    paths:
+      - pkgs/overlays.nix
+
+jobs:
+  update-hash:
+    runs-on: ubuntu-latest
+    # Only run on Renovate PRs for gemini-cli
+    if: startsWith(github.head_ref, 'renovate/') && contains(github.event.pull_request.title, 'gemini-cli')
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: DeterminateSystems/nix-installer-action@v17
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Update gemini-cli-bin hash
+        run: .github/scripts/update-gemini-hash.sh
+
+      - name: Check for changes
+        id: changes
+        run: |
+          if git diff --quiet pkgs/overlays.nix; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Commit updated hash
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add pkgs/overlays.nix
+          git commit -m "fix(nix): update gemini-cli-bin hash"
+          git push


### PR DESCRIPTION
## Summary
Fix Renovate artifact failure by replacing `postUpgradeTasks` with a GitHub Action workflow.

## Problem
The hosted Mend Renovate GitHub App doesn't support `postUpgradeTasks` - it requires `allowedCommands` configuration which is only available in self-hosted Renovate.

## Solution
- Remove `postUpgradeTasks` from `renovate.json`
- Add `.github/workflows/update-nix-hash.yaml` that:
  - Triggers on PRs that modify `pkgs/overlays.nix`
  - Only runs on Renovate PRs for gemini-cli
  - Runs the hash update script
  - Commits the updated hash back to the PR branch

## Test Plan
- [ ] Merge this PR
- [ ] Close and re-open PR #34 (or wait for Renovate to recreate it)
- [ ] Verify the `update-nix-hash` workflow runs and commits the correct hash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a workflow that auto-commits to PR branches with `contents: write`, so mis-scoping the `if`/path filters could cause unexpected pushes or CI churn.
> 
> **Overview**
> Moves gemini-cli Nix hash refreshing out of Renovate by removing the `postUpgradeTasks` hook in `.github/renovate.json` and leaving Renovate to only bump the `google-gemini/gemini-cli` version.
> 
> Adds a new `update-nix-hash` GitHub Actions workflow that runs on Renovate PRs touching `pkgs/overlays.nix`, executes `.github/scripts/update-gemini-hash.sh`, and commits/pushes any resulting hash change back to the PR branch.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e1e938250b8c5eecfbabc3282df6589e5597928. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->