### PR TITLE
chore: remove gh-aipr and ignore claude worktree artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ ergodox/build
 nix/config.dev.nix
 secrets/**
 config.nix
+.claude/worktrees/
+.claude/settings.local.json

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ Five home configurations built via `mkHome system modules`:
 | `homebook` | aarch64-darwin   | `home/home.nix` + `home/darwin.nix`  |
 | `work`     | aarch64-darwin   | `home/work.nix`                      |
 
-Overlays applied globally: `llm-agents.nix`, `gh-aipr`, custom `shell-utils`.
+Overlays applied globally: `llm-agents.nix`, custom `shell-utils`.
 
 ### Module Hierarchy
 

--- a/flake.lock
+++ b/flake.lock
@@ -6,7 +6,7 @@
           "llm-agents",
           "nixpkgs"
         ],
-        "systems": "systems_2"
+        "systems": "systems"
       },
       "locked": {
         "lastModified": 1769353768,
@@ -19,45 +19,6 @@
       "original": {
         "owner": "numtide",
         "repo": "blueprint",
-        "type": "github"
-      }
-    },
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1731533236,
-        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
-    "gh-aipr": {
-      "inputs": {
-        "flake-utils": "flake-utils",
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1754770147,
-        "narHash": "sha256-IZFrtd/ltJ3JkzwFoICvPH3MP1KuEY88tVaa2d3hceU=",
-        "owner": "wannabehero",
-        "repo": "gh-aipr",
-        "rev": "40d356b9b607032f0a64a690c984c74ddfe4da90",
-        "type": "github"
-      },
-      "original": {
-        "owner": "wannabehero",
-        "repo": "gh-aipr",
         "type": "github"
       }
     },
@@ -122,28 +83,12 @@
     },
     "root": {
       "inputs": {
-        "gh-aipr": "gh-aipr",
         "home-manager": "home-manager",
         "llm-agents": "llm-agents",
         "nixpkgs": "nixpkgs"
       }
     },
     "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
-      }
-    },
-    "systems_2": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",

--- a/flake.nix
+++ b/flake.nix
@@ -5,8 +5,6 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     home-manager.url = "github:nix-community/home-manager/master";
     home-manager.inputs.nixpkgs.follows = "nixpkgs";
-    gh-aipr.url = "github:wannabehero/gh-aipr";
-    gh-aipr.inputs.nixpkgs.follows = "nixpkgs";
     llm-agents.url = "github:numtide/llm-agents.nix";
     llm-agents.inputs.nixpkgs.follows = "nixpkgs";
   };
@@ -21,7 +19,6 @@
       self,
       home-manager,
       nixpkgs,
-      gh-aipr,
       llm-agents,
     }:
     let
@@ -33,7 +30,6 @@
 
       overlays = [
         llm-agents.overlays.default
-        gh-aipr.overlays.pkgs
         (final: prev: {
           shell-utils = final.callPackage ./pkgs/shell-utils.nix { };
         })

--- a/home/modules/git.nix
+++ b/home/modules/git.nix
@@ -8,10 +8,7 @@ in
     boop = "${pkgs.git}/bin/git boop";
   };
 
-  programs.gh = {
-    enable = true;
-    extensions = [ pkgs.gh-aipr ];
-  };
+  programs.gh.enable = true;
 
   programs.git = {
     enable = true;
@@ -98,6 +95,8 @@ in
       ".env.production*"
       "tmp"
       "temp"
+      ".claude/worktrees/"
+      ".claude/settings.local.json"
     ];
   };
 }


### PR DESCRIPTION
## Summary
Removes the `gh-aipr` GitHub CLI extension and its flake input entirely, and adds Claude Code worktree artifacts to both the repo and global gitignores.

## Changes
- Remove `gh-aipr` flake input, overlay (`gh-aipr.overlays.pkgs`), and `gh` extension from `home/modules/git.nix`
- Update `flake.lock` (drops `gh-aipr`, `flake-utils`, `systems_2` stale entries)
- Add `.claude/worktrees/` and `.claude/settings.local.json` to `.gitignore`
- Add same entries to global gitignore via `programs.git.ignores` in `home/modules/git.nix`
- Update `AGENTS.md` overlay documentation

## Test Plan
- [ ] `nix flake check` passes
- [ ] `nix build .#homebook` evaluates cleanly

Signed-off-by: Jonathan Pulsifer <jonathan@pulsifer.ca>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily configuration/lockfile cleanup; main impact is that the `gh-aipr` CLI extension will no longer be installed or available.
> 
> **Overview**
> Removes the `gh-aipr` flake input/overlay and drops the GitHub CLI extension configuration, leaving `programs.gh` enabled without extra extensions.
> 
> Updates `flake.lock` to prune `gh-aipr`/`flake-utils` (and the redundant `systems_2` entry), and adds `.claude/worktrees/` plus `.claude/settings.local.json` to both the repo `.gitignore` and the global `programs.git.ignores`. Documentation in `AGENTS.md` is updated to reflect the overlay removal.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e733fd56bed3ae2726a60214a5919056eb1536ba. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->