### PR TITLE
feat(peon-ping): add peon-ping package and home-manager module

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
         llm-agents.overlays.default
         (final: prev: {
           shell-utils = final.callPackage ./pkgs/shell-utils.nix { };
+          peon-ping = final.callPackage ./pkgs/peon-ping.nix { };
         })
       ];
 

--- a/home/home.nix
+++ b/home/home.nix
@@ -15,6 +15,7 @@ in
     modules/javascript.nix
     modules/kubernetes.nix
     modules/ai
+    modules/peon-ping.nix
     modules/ssh.nix
     modules/terraform.nix
   ];
@@ -38,6 +39,12 @@ in
       NPM_CONFIG_PREFIX = "$HOME/.npm/bin";
       VAULT_ADDR = "https://vault.lolwtf.ca";
     };
+  };
+
+  programs.peon-ping = {
+    enable = true;
+    enableClaudeCodeIntegration = true;
+    enableGeminiIntegration = true;
   };
 
   services.gpg-agent = lib.mkIf isLinux {

--- a/home/modules/ai/default.nix
+++ b/home/modules/ai/default.nix
@@ -74,9 +74,15 @@ let
     mcp = mapAttrs (
       _: server:
       if server ? url then
-        { type = "remote"; url = server.url; }
+        {
+          type = "remote";
+          url = server.url;
+        }
       else
-        { type = "local"; command = [ server.command ] ++ server.args; }
+        {
+          type = "local";
+          command = [ server.command ] ++ server.args;
+        }
     ) mcpServers;
     plugin = [ "./plugins/peon-ping.ts" ];
   };

--- a/home/modules/gcloud.nix
+++ b/home/modules/gcloud.nix
@@ -1,4 +1,4 @@
-w{
+{
   lib,
   pkgs,
   config,

--- a/home/modules/peon-ping.nix
+++ b/home/modules/peon-ping.nix
@@ -1,0 +1,230 @@
+# Adapted from https://github.com/nix-community/home-manager/pull/8750
+# Vendored locally until the upstream PR is merged.
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.programs.peon-ping;
+  jsonFormat = pkgs.formats.json { };
+
+  defaultOgPacksSource = pkgs.fetchFromGitHub {
+    owner = "PeonPing";
+    repo = "og-packs";
+    rev = "v1.2.0";
+    hash = "sha256-UZ6F70VBEDLzgFF3py1f5qKxgKbYPmSikXFgo8fRo8M=";
+  };
+
+  hookCommand = "${cfg.package}/bin/peon";
+  adapterDir = "${cfg.package}/lib/peon-ping/adapters";
+
+  hookEntry = event: {
+    matcher = "";
+    hooks = [
+      (
+        {
+          type = "command";
+          command = hookCommand;
+          timeout = 10;
+        }
+        // lib.optionalAttrs (event != "SessionStart") { async = true; }
+      )
+    ];
+  };
+
+  claudeCodeHooks = lib.listToAttrs (
+    map (event: lib.nameValuePair event [ (hookEntry event) ]) cfg.claudeCodeHookEvents
+  );
+
+  claudeCodeHooksJson = builtins.toJSON claudeCodeHooks;
+in
+{
+  options.programs.peon-ping = {
+    enable = lib.mkEnableOption "peon-ping, a notification sound player for AI coding agents";
+
+    package = lib.mkPackageOption pkgs "peon-ping" { };
+
+    settings = lib.mkOption {
+      inherit (jsonFormat) type;
+      default = { };
+      example = {
+        active_pack = "peon";
+        volume = 0.5;
+        enabled = true;
+        desktop_notifications = true;
+        categories = {
+          "session.start" = true;
+          "task.complete" = true;
+          "input.required" = true;
+        };
+      };
+      description = ''
+        Declarative peon-ping configuration written to
+        {file}`~/.claude/hooks/peon-ping/config.json`.
+
+        When non-empty, the config file is managed by Home Manager as an
+        immutable symlink. When left empty (the default), a mutable default
+        config is seeded on first activation so that the `peon` CLI and
+        Claude Code skills can modify it at runtime.
+      '';
+    };
+
+    packs = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [ "peon" ];
+      example = [
+        "peon"
+        "peon_de"
+        "aoe2"
+      ];
+      description = ''
+        Sound pack names to install from {option}`ogPacksSource`.
+        Each name corresponds to a subdirectory in the og-packs repository.
+      '';
+    };
+
+    ogPacksSource = lib.mkOption {
+      type = lib.types.package;
+      default = defaultOgPacksSource;
+      defaultText = lib.literalExpression ''
+        pkgs.fetchFromGitHub {
+          owner = "PeonPing";
+          repo = "og-packs";
+          rev = "v1.2.0";
+          hash = "sha256-UZ6F70VBEDLzgFF3py1f5qKxgKbYPmSikXFgo8fRo8M=";
+        }
+      '';
+      description = ''
+        Source derivation containing sound packs. Pack names in
+        {option}`packs` are resolved as subdirectories of this source.
+      '';
+    };
+
+    enableClaudeCodeIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to automatically configure Claude Code hooks for
+        peon-ping integration via an activation script.
+      '';
+    };
+
+    enableGeminiIntegration = lib.mkOption {
+      type = lib.types.bool;
+      default = false;
+      description = ''
+        Whether to automatically configure Gemini CLI hooks for
+        peon-ping integration via an activation script.
+      '';
+    };
+
+    claudeCodeHookEvents = lib.mkOption {
+      type = lib.types.listOf lib.types.str;
+      default = [
+        "SessionStart"
+        "SessionEnd"
+        "UserPromptSubmit"
+        "Stop"
+        "Notification"
+        "PermissionRequest"
+      ];
+      description = ''
+        Claude Code hook events to register peon-ping for.
+        Each event fires the `peon` command which reads the event
+        from stdin and plays the appropriate sound.
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    home.packages = [ cfg.package ];
+
+    home.file = {
+      ".claude/hooks/peon-ping/config.json" = lib.mkIf (cfg.settings != { }) {
+        source = jsonFormat.generate "peon-ping-config.json" cfg.settings;
+      };
+    };
+
+    # Copy packs as real files (not symlinks) so peon's path traversal
+    # check (os.path.realpath + startswith) doesn't reject nix store paths.
+    # Also symlink peon.sh into the hooks dir so `peon status` detects the
+    # Claude Code integration as "installed".
+    home.activation.installPeonPingPacks = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+      peonDir="''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+      packsDir="$peonDir/packs"
+      run mkdir -p "$packsDir"
+      ${lib.concatMapStringsSep "\n" (name: ''
+        if [ -L "$packsDir/${name}" ]; then
+          run rm "$packsDir/${name}"
+        fi
+        run rm -rf "$packsDir/${name}"
+        run cp -rL "${cfg.ogPacksSource}/${name}" "$packsDir/${name}"
+        run chmod -R u+w "$packsDir/${name}"
+      '') cfg.packs}
+      # peon status checks for peon.sh and adapters/ in the hooks dir
+      run ln -sf "${cfg.package}/lib/peon-ping/peon.sh" "$peonDir/peon.sh"
+      run ln -sfn "${adapterDir}" "$peonDir/adapters"
+      verboseEcho "Installed peon-ping packs: ${lib.concatStringsSep ", " cfg.packs}"
+    '';
+
+    # Seed a mutable default config when no declarative settings are provided
+    home.activation.seedPeonPingConfig = lib.mkIf (cfg.settings == { }) (
+      lib.hm.dag.entryAfter [ "linkGeneration" ] ''
+        peonConfigDir="''${CLAUDE_CONFIG_DIR:-$HOME/.claude}/hooks/peon-ping"
+        peonConfigFile="$peonConfigDir/config.json"
+        if [ ! -f "$peonConfigFile" ]; then
+          run mkdir -p "$peonConfigDir"
+          run cp "${cfg.package}/lib/peon-ping/config.json" "$peonConfigFile"
+          run chmod u+w "$peonConfigFile"
+          verboseEcho "Seeded peon-ping default config at $peonConfigFile"
+        fi
+      ''
+    );
+
+    # Merge peon-ping hooks into Claude Code settings.json
+    home.activation.claudeCodePeonPingHooks = lib.mkIf cfg.enableClaudeCodeIntegration (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        CLAUDE_SETTINGS="$HOME/.claude/settings.json"
+        PEON_HOOKS='${claudeCodeHooksJson}'
+
+        if [ -f "$CLAUDE_SETTINGS" ]; then
+          ${pkgs.jq}/bin/jq --argjson peon "$PEON_HOOKS" '
+            .hooks as $existing |
+            reduce ($peon | keys[]) as $event (.; .hooks[$event] = (($existing[$event] // []) + $peon[$event]))
+          ' "$CLAUDE_SETTINGS" > "$CLAUDE_SETTINGS.tmp" && mv "$CLAUDE_SETTINGS.tmp" "$CLAUDE_SETTINGS"
+        else
+          mkdir -p "$(dirname "$CLAUDE_SETTINGS")"
+          echo '{"hooks": '"$PEON_HOOKS"'}' | ${pkgs.jq}/bin/jq . > "$CLAUDE_SETTINGS"
+        fi
+      ''
+    );
+
+    # Merge peon-ping hooks into Gemini CLI settings.json
+    home.activation.geminiPeonPingHooks = lib.mkIf cfg.enableGeminiIntegration (
+      lib.hm.dag.entryAfter [ "writeBoundary" ] ''
+        GEMINI_SETTINGS="''${GEMINI_CONFIG_DIR:-$HOME/.gemini}/settings.json"
+        ADAPTER="$HOME/.claude/hooks/peon-ping/adapters/gemini.sh"
+
+        # Build hooks JSON with the resolved adapter path
+        GEMINI_HOOKS=$(${pkgs.jq}/bin/jq -n \
+          --arg adapter "$ADAPTER" \
+          '{
+            SessionStart: [{matcher: "startup", type: "command", command: ("bash " + $adapter + " SessionStart")}],
+            AfterAgent:   [{matcher: "*", type: "command", command: ("bash " + $adapter + " AfterAgent")}],
+            AfterTool:    [{matcher: "*", type: "command", command: ("bash " + $adapter + " AfterTool")}],
+            Notification: [{matcher: "*", type: "command", command: ("bash " + $adapter + " Notification")}]
+          }')
+
+        if [ -f "$GEMINI_SETTINGS" ]; then
+          ${pkgs.jq}/bin/jq --argjson peon "$GEMINI_HOOKS" '.hooks = $peon' \
+            "$GEMINI_SETTINGS" > "$GEMINI_SETTINGS.tmp" && mv "$GEMINI_SETTINGS.tmp" "$GEMINI_SETTINGS"
+        else
+          mkdir -p "$(dirname "$GEMINI_SETTINGS")"
+          echo '{}' | ${pkgs.jq}/bin/jq --argjson peon "$GEMINI_HOOKS" '.hooks = $peon' > "$GEMINI_SETTINGS"
+        fi
+      ''
+    );
+  };
+}

--- a/home/work.nix
+++ b/home/work.nix
@@ -22,6 +22,7 @@ in
     modules/javascript.nix
     modules/kubernetes.nix
     modules/ai
+    modules/peon-ping.nix
     modules/terraform.nix
   ];
 
@@ -62,6 +63,12 @@ in
       ];
       gpg.ssh.program = "/Applications/1Password.app/Contents/MacOS/op-ssh-sign";
     };
+  };
+
+  programs.peon-ping = {
+    enable = true;
+    enableClaudeCodeIntegration = true;
+    enableGeminiIntegration = true;
   };
 
   programs.mise = {

--- a/pkgs/peon-ping.nix
+++ b/pkgs/peon-ping.nix
@@ -1,0 +1,82 @@
+{
+  lib,
+  stdenvNoCC,
+  fetchFromGitHub,
+  bash,
+  makeWrapper,
+  installShellFiles,
+  python3,
+  curl,
+  coreutils,
+  libnotify,
+}:
+
+stdenvNoCC.mkDerivation (finalAttrs: {
+  pname = "peon-ping";
+  version = "2.8.1";
+
+  src = fetchFromGitHub {
+    owner = "PeonPing";
+    repo = "peon-ping";
+    tag = "v${finalAttrs.version}";
+    hash = "sha256-eTXYNMUxEweBtm1NDM4iSWwzqMM2dJfDJSFDp1FoDpM=";
+  };
+
+  nativeBuildInputs = [
+    makeWrapper
+    installShellFiles
+  ];
+
+  buildInputs = [ bash ];
+
+  dontBuild = true;
+
+  installPhase = ''
+    runHook preInstall
+
+    install -Dm755 peon.sh $out/lib/peon-ping/peon.sh
+    install -Dm644 config.json $out/lib/peon-ping/config.json
+
+    # Install adapter scripts and helper scripts for IDE integrations
+    cp -r adapters $out/lib/peon-ping/adapters
+    chmod +x $out/lib/peon-ping/adapters/*.sh
+    cp -r scripts $out/lib/peon-ping/scripts
+    cp -r skills $out/lib/peon-ping/skills
+
+    makeWrapper $out/lib/peon-ping/peon.sh $out/bin/peon \
+      --prefix PATH : ${
+        lib.makeBinPath (
+          [
+            coreutils
+            curl
+            python3
+          ]
+          ++ lib.optionals stdenvNoCC.isLinux [ libnotify ]
+        )
+      }
+
+    installShellCompletion --cmd peon \
+      --bash completions.bash \
+      --fish completions.fish
+
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Notification sound player for AI coding agents";
+    longDescription = ''
+      peon-ping plays game character voice lines when AI coding agents
+      (Claude Code, Cursor, Codex, etc.) need your attention. It supports
+      desktop and mobile notifications, multiple sound packs, and integrates
+      as hooks in IDE configurations.
+
+      Sound packs must be installed separately into
+      ~/.claude/hooks/peon-ping/packs/ — see the project README for details.
+    '';
+    homepage = "https://github.com/PeonPing/peon-ping";
+    changelog = "https://github.com/PeonPing/peon-ping/blob/v${finalAttrs.version}/CHANGELOG.md";
+    license = lib.licenses.mit;
+    platforms = lib.platforms.linux ++ lib.platforms.darwin;
+    mainProgram = "peon";
+  };
+})


### PR DESCRIPTION
## Summary
Vendor peon-ping v2.8.1 and an adapted home-manager module (from [nix-community/home-manager#8750](https://github.com/nix-community/home-manager/pull/8750)) so it can be used before the upstream PRs are merged. Includes cross-platform support (macOS + Linux), Claude Code hooks integration, and Gemini CLI adapter hooks.

## Changes
- **`pkgs/peon-ping.nix`** — Local package derivation for peon-ping v2.8.1 with macOS support (libnotify conditional on Linux), installs adapters/scripts/skills
- **`home/modules/peon-ping.nix`** — Home-manager module adapted from upstream PR: pack installation (as real files, not symlinks, to avoid realpath security check), Claude Code + Gemini CLI hook integration via activation scripts, mutable config seeding
- **`flake.nix`** — Added peon-ping to overlay
- **`home/home.nix`** + **`home/work.nix`** — Import module, enable with Claude Code + Gemini integration
- **`home/modules/gcloud.nix`** — Fix pre-existing syntax error (stray `w` prefix)
- **`home/modules/ai/default.nix`** — Formatting only (linter)

## Test Plan
- [x] `nix build .#legacyPackages.aarch64-darwin.peon-ping` — package builds on macOS
- [x] `peon help` — binary runs correctly
- [x] `nix build .#default --dry-run` — work config evaluates
- [x] `nix build .#homebook --dry-run` — homebook config evaluates
- [x] `nix eval .#packages.x86_64-linux.default --apply 'x: "ok"'` — Linux config evaluates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new activation scripts that mutate local tool config files (`~/.claude/settings.json`, Gemini settings) and manage on-disk assets, which could override user changes or break agent hook behavior if misconfigured.
> 
> **Overview**
> Vendors `peon-ping` v2.8.1 as a new Nix package and exposes it via the flake overlay so it can be installed cross-platform.
> 
> Adds a Home Manager module (`programs.peon-ping`) that installs sound packs into `~/.claude/hooks/peon-ping`, optionally seeds a mutable default config, and can automatically merge hook configurations into Claude Code and Gemini CLI settings via activation scripts; the module is imported and enabled in `home.nix` and `work.nix`.
> 
> Also fixes a small syntax issue in `modules/gcloud.nix` and applies formatting-only changes in `modules/ai/default.nix`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31bdd429295dd67f69d53c129547b82988b16d6a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->