### PR TITLE
CI workflow failure

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,7 @@
         basic = mkHome "x86_64-linux" [ ./home/basic.nix ];
         pulse = mkHome "x86_64-linux" [ ./home/pulse.nix ];
         arm = mkHome "aarch64-linux" [ ./home/basic.nix ];
+        armPulse = mkHome "aarch64-linux" [ ./home/pulse.nix ];
         homebook = mkHome "aarch64-darwin" [
           ./home/home.nix
           ./home/darwin.nix
@@ -85,7 +86,7 @@
           pkgsBySystem."x86_64-linux".callPackage ./pkgs/update-moonpay-cli.nix
             { };
         aarch64-linux.default = homeConfigurations.arm.activationPackage;
-        aarch64-linux.pulse = homeConfigurations.pulse.activationPackage;
+        aarch64-linux.pulse = homeConfigurations.armPulse.activationPackage;
         aarch64-linux.update-moonpay-cli =
           pkgsBySystem."aarch64-linux".callPackage ./pkgs/update-moonpay-cli.nix
             { };
@@ -95,8 +96,6 @@
           pkgsBySystem."aarch64-darwin".callPackage ./pkgs/update-moonpay-cli.nix
             { };
       };
-
-      legacyPackages = pkgsBySystem;
 
       # home-manager modules, not NixOS modules
       homeModules = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix CI workflow failure by addressing flake output issues.

Removed `legacyPackages` output which caused `nix flake check` to fail with newer Nix versions due to evaluation errors in `nixpkgs-unstable`, and corrected a system mismatch for the `aarch64-linux.pulse` package.

---
<p><a href="https://cursor.com/agents/bc-eadf20d3-988a-4404-9cb5-8e32c46923db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eadf20d3-988a-4404-9cb5-8e32c46923db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->